### PR TITLE
fix Anaconda environment name

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: base
+name: ThinkBayes2
 channels:
   - unidata
   - conda-forge


### PR DESCRIPTION
The environment.yml file install the dependencies in the 'base' environment.
However this environment already exists and is the Anaconda default. It causes
an error when trying to follow the installation steps in the README.md file.

The README offer to activate the environment with the name ThinkBayes2. Use this
name instead in the yml file.