### PR TITLE
PercentileRanks(self, xs) param error

### DIFF
--- a/thinkbayes2/thinkbayes2.py
+++ b/thinkbayes2/thinkbayes2.py
@@ -1223,7 +1223,7 @@ class Cdf:
 
         returns: array of percentile ranks in the range 0 to 100
         """
-        return self.Probs(x) * 100
+        return self.Probs(xs) * 100
 
     def Random(self):
         """Chooses a random value from this distribution."""


### PR DESCRIPTION
PercentileRanks(self, xs) param is xs, but use x in function body 
```
    def PercentileRanks(self, xs):
        """Returns the percentile ranks of the values in xs.

        xs: potential value in the CDF

        returns: array of percentile ranks in the range 0 to 100
        """
        return self.Probs(x) * 100
```