### PR TITLE
add requirements.txt for pip users

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+empiricaldist


### PR DESCRIPTION
Hi, Allen. I write Python for a living, and it took a while for me to figure out that `empiricaldist` was available via `pypi`. I don't use Anaconda, so most of the boilerplate for that didn't apply to me. I did not include `pandas`, `numpy` or `jupyter` in the `requirements.txt`. I'll leave that decision to you. They're more obvious to the reader, and many people install these outside the `virtualenv` anyway.