### PR TITLE
add ignore jupyter checkpoints and output tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# jupyter checkpoints
+**/.ipynb_checkpoints/
+
+# output tables
+**/tables/


### PR DESCRIPTION
* Ignore `.ipynb_checkpoints` --> students should not want to commit this with their work
* Ignore text tables --> I'm not sure why they're saved? Anyway, I don't see these side effects as relevant when committing answers to exercises.