### PR TITLE
A small typo in the Monty Hall Problem section of chap02.ipynb

### DIFF
--- a/notebooks/chap02.ipynb
+++ b/notebooks/chap02.ipynb
@@ -539,7 +539,7 @@
     "If you have not encountered this problem before, you might find that\n",
     "answer surprising. You would not be alone; many people have the strong\n",
     "intuition that it doesn't matter if you stick or switch. There are two\n",
-    "doors left, they reason, so the chance that the car is behind Door A is 50%. But that is wrong.\n",
+    "doors left, they reason, so the chance that the car is behind Door 1 is 50%. But that is wrong.\n",
     "\n",
     "To see why, it can help to use a Bayes table. We start with three\n",
     "hypotheses: the car might be behind Door 1, 2, or 3. According to the\n",


### PR DESCRIPTION
Hi Allen,

In the Monty Hall Problem section, there is a small typo of the following sentence:

"There are two doors left, they reason, so the chance that the car is behind Door A is 50%. But that is wrong".

=> "Door A" should be "Door 1".

Many thanks.

Danh