### PR TITLE
Install empiricaldist from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,5 +29,4 @@ dependencies:
   - nbmake
   - jupyter-book
   - ghp-import
-  - pip:
-    - empiricaldist
+  - empiricaldist>=0.6.7


### PR DESCRIPTION
**tl;dr** Install empiricaldist with conda now that it is [available from conda-forge](https://anaconda.org/conda-forge/empiricaldist)

## Background

A minimum of 0.6.7 is required because version 0.6.6 is broken (it doesn't import matplotlib, which it requires for its
plotting methods)

https://github.com/conda-forge/empiricaldist-feedstock/pull/1
https://anaconda.org/conda-forge/empiricaldist/files?version=0.6.7

## Testing

I confirmed that I could build all the main chapter notebooks with this updated environment:

```
mamba env create --file environment.yml
conda activate ThinkBayes2

for nb in chap*.ipynb
do
  jupyter execute $nb
done
```

I also attempted to build the non-chapter notebook, but `clustering.ipynb` fails because the environment doesn't have scikit-learn installed:

```
ModuleNotFoundError: No module named 'sklearn'
```

Given how it already takes so long to solve and build the conda environment, and also that [the clustering notebook is not included in the online version of the book](https://allendowney.github.io/ThinkBayes2/clustering.html), I decided to not add it in this PR.

## Other

Also note that per our discussion in https://github.com/AllenDowney/ThinkBayes2/pull/56#issuecomment-1117536918, I took a stab at creating two separate environments: one for readers, and one for you to build the book. I loss motivation for now because:

1. The reader-only env wasn't that light-weight anyways. The final few chapters ended up requiring a bunch of packages that I had hoped to remove
2. I ran into the frustrating [pymc3/arviz error](https://github.com/conda-forge/pymc3-feedstock/issues/77) that [you had previously run into](https://discourse.pymc.io/t/attributeerror-module-arviz-has-no-attribute-geweke/6818/13). Pinning to old versions of these dependencies limits the long-term usefulness of the book's code (eg it can't benefit from bug fixes in later releases). When I tried to force conda to install newer versions on macOS, the conflict was due to some low-level package (I can't remember which), which would be non-trivial to fix or workaround
3. I got errors like missing scikit-learn in `clustering.ipynb` (as mentioned above). It's unclear to me which code is expected to be able to be executed using the conda env

In case it could be useful to you, here's what I had when I stopped:

https://github.com/jdblischak/ThinkBayes2/tree/more-conda-updates
https://github.com/jdblischak/ThinkBayes2/blob/more-conda-updates/environment.yml
https://github.com/jdblischak/ThinkBayes2/blob/more-conda-updates/environment-book.yml